### PR TITLE
Make X axis of PanTilt UI match the motor control service

### DIFF
--- a/webapp/src/components/PanTilt.tsx
+++ b/webapp/src/components/PanTilt.tsx
@@ -120,9 +120,9 @@ export function PanTilt({
         <div className={st.outerContainer}>
             <h4>Pan</h4>
             <div className={st.servoRange}>
-                <div>{panServo.min_angle}&deg;</div>
-                <div className={st.spacer} />
                 <div>{panServo.max_angle}&deg;</div>
+                <div className={st.spacer} />
+                <div>{panServo.min_angle}&deg;</div>
             </div>
             <div className={st.innerContainer}>
                 <div className={st.tiltLabelsContainer}>

--- a/webapp/src/util/angleUtils.ts
+++ b/webapp/src/util/angleUtils.ts
@@ -36,7 +36,10 @@ export function mapPanTiltToXYSquare(
 ): [number, number] {
     const xf =
         panAngle - panServo.min_angle / panServo.max_angle - panServo.min_angle;
-    const x = (xf * containerSize) / (panServo.max_angle - panServo.min_angle);
+    const x =
+        containerSize -
+        (xf * containerSize) / (panServo.max_angle - panServo.min_angle);
+
     const yf =
         tiltAngle -
         tiltServo.min_angle / tiltServo.max_angle -
@@ -55,8 +58,8 @@ export function mapXYToPanTilt(
     containerSize: number
 ): [number, number] {
     const panAngle =
-        (x * (panServo.max_angle - panServo.min_angle)) / containerSize +
-        panServo.min_angle;
+        panServo.max_angle -
+        (x * (panServo.max_angle - panServo.min_angle)) / containerSize;
     const tiltAngle =
         (y * (tiltServo.max_angle - tiltServo.min_angle)) / containerSize +
         tiltServo.min_angle;


### PR DESCRIPTION
The base servo (pan) orientation determines that x = 0 is visually on the right and x = 180 on the left.  