### PR TITLE
Make play loop around all filtered files

### DIFF
--- a/webapp/src/VidViewerDialog/Dateline.tsx
+++ b/webapp/src/VidViewerDialog/Dateline.tsx
@@ -38,7 +38,7 @@ export const DateLine: React.FC<DateLineProps> = ({
             return (
                 <div
                     key={`AM-${index}`}
-                    data-rangeStart={range.start.toString()}
+                    data-rangestart={range.start.toString()}
                     className={st.activityMarker}
                     style={{ top: `${topPct}%`, height: `${heightPct}%` }}
                 />

--- a/webapp/src/VidViewerDialog/Viewer.tsx
+++ b/webapp/src/VidViewerDialog/Viewer.tsx
@@ -16,6 +16,8 @@ interface ViewerProps {
     // date range of the viewer window
     windowRange: du.DateRange;
 
+    onNextFile: () => void;
+    onPrevFile: () => void;
     onPlayheadChange: (newPlayheadPosition: Date) => void;
 }
 
@@ -23,6 +25,8 @@ export const Viewer: React.FC<ViewerProps> = ({
     fileNames,
     playheadPosition,
     windowRange,
+    onNextFile,
+    onPrevFile,
     onPlayheadChange,
 }) => {
     const videoRef = useRef<HTMLVideoElement>(null);
@@ -41,18 +45,6 @@ export const Viewer: React.FC<ViewerProps> = ({
         [fileNames, fileNamesIndex]
     );
 
-    const handleVideoEnded = () => {
-        if (fileNamesIndex > 0) {
-            onPlayheadChange(
-                du.parseFilenameDate(fileNames[fileNamesIndex - 1])
-            );
-        } else {
-            onPlayheadChange(
-                du.parseFilenameDate(fileNames[fileNames.length - 1])
-            );
-        }
-    };
-
     const handlePlayPause = () => {
         try {
             if (videoRef.current) {
@@ -67,28 +59,6 @@ export const Viewer: React.FC<ViewerProps> = ({
         }
     };
 
-    const handleForward = () => {
-        if (fileNamesIndex > 0) {
-            onPlayheadChange(
-                du.parseFilenameDate(fileNames[fileNamesIndex - 1])
-            );
-        } else {
-            onPlayheadChange(
-                du.parseFilenameDate(fileNames[fileNames.length - 1])
-            );
-        }
-    };
-
-    const handleBack = () => {
-        if (fileNamesIndex < fileNames.length - 1) {
-            onPlayheadChange(
-                du.parseFilenameDate(fileNames[fileNamesIndex + 1])
-            );
-        } else {
-            onPlayheadChange(du.parseFilenameDate(fileNames[0]));
-        }
-    };
-
     return (
         <div className={st.viewer}>
             <div className="playheadDateTime">
@@ -100,12 +70,12 @@ export const Viewer: React.FC<ViewerProps> = ({
                 controls
                 autoPlay
                 src={videoUrl}
-                onEnded={handleVideoEnded}
+                onEnded={onNextFile}
             />
             <PlayerControls
                 isPlaying={!videoRef.current?.paused}
-                onBack10s={handleBack}
-                onForward10s={handleForward}
+                onBack10s={onPrevFile}
+                onForward10s={onNextFile}
                 onPlayPause={handlePlayPause}
             />
             <Timeline


### PR DESCRIPTION
Was previously wrapping around in the windowed files (timeline files)  when the playhead position > latest file or < earliest.  This PR changes it to move the timeline window and iterate over all filter range files.