### PR TITLE
Add ability to click+drag scrub timeline

### DIFF
--- a/webapp/src/VidViewerDialog/Timeline.module.css
+++ b/webapp/src/VidViewerDialog/Timeline.module.css
@@ -1,5 +1,6 @@
 @import "../vars.css";
 .outerContainer {
+    position: relative;
     display: flex;
     flex-direction: column;
     position: relative;
@@ -52,4 +53,18 @@
     padding: 0 5px;
     color: var(--color-black);
     font-size: 12px;
+}
+
+.scrubberPreview {
+    position: absolute;
+    bottom: 0px;
+    background-color: var(--color-dialog-backdrop);
+    border: 1px solid var(--color-dialog-frame);
+    border-radius: var(--radius-dialog-md);
+    padding: 20px;
+    z-index: 3;
+}
+.scrubberDate {
+    font-size: 14px;
+    color: var(--color-white);
 }

--- a/webapp/src/VidViewerDialog/Timeline.tsx
+++ b/webapp/src/VidViewerDialog/Timeline.tsx
@@ -1,9 +1,10 @@
-import { useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import * as du from "./dateUtils";
 
 import st from "./Timeline.module.css";
-import { thumbUrl } from "../util/vidUtils";
+import { largeThumbUrl, thumbUrl } from "../util/vidUtils";
+import { AnyTouchEvent, getClientXY } from "./touchUtils";
 
 interface TimelineProps {
     // a string array of base file names retrieved from the basic_bot vision service
@@ -27,6 +28,13 @@ export const Timeline: React.FC<TimelineProps> = ({
     playheadPosition,
     onPlayheadChange,
 }) => {
+    const timelineRef = useRef<HTMLDivElement>(null);
+    // The timeline was clicked and the mouse/finger is still down
+    const [isScrubbing, setIsScrubbing] = useState(false);
+    // The date that the playhead is currently over or null if the playhead
+    // is not over a date within the duration of a fileNames member
+    const [scrubDate, setScrubDate] = useState<Date | null>(null);
+
     const thumbs = useMemo(() => {
         if (!fileNames.length) return null;
         const _thumbs = [];
@@ -57,6 +65,7 @@ export const Timeline: React.FC<TimelineProps> = ({
     }, [fileNames, fileNamesIndex, windowRange]);
 
     const playheadPct = useMemo(() => {
+        console.log("Timeline got playheadPosition", playheadPosition);
         if (!windowRange || !windowRange.duration) return 0;
         const secondsWindowRange = windowRange.duration / 1000;
         const secondsFromStart =
@@ -64,19 +73,107 @@ export const Timeline: React.FC<TimelineProps> = ({
         return (secondsFromStart / secondsWindowRange) * 100;
     }, [windowRange, playheadPosition]);
 
-    const handleTimelineClick = (event: React.MouseEvent<HTMLDivElement>) => {
-        const rect = event.currentTarget.getBoundingClientRect();
-        const x = event.clientX - rect.left;
-        const pct = (x / rect.width) * 100;
-        const newPlayheadPosition = new Date(
-            windowRange.start.getTime() + (windowRange.duration * pct) / 100
-        );
-        onPlayheadChange(newPlayheadPosition);
+    const getDateFromEventPoint = useCallback(
+        (event: AnyTouchEvent, windowRange: du.DateRange): Date => {
+            if (!timelineRef.current) return windowRange.start;
+            const clientX = getClientXY(event)[0];
+            const rect = timelineRef.current.getBoundingClientRect();
+
+            if (clientX < rect.left) return windowRange.start;
+            if (clientX > rect.right) return windowRange.end;
+
+            const xf = (clientX - rect.left) / rect.width;
+            return new Date(
+                windowRange.start.getTime() + windowRange.duration * xf
+            );
+        },
+        [windowRange] // eslint-disable-line react-hooks/exhaustive-deps
+    );
+
+    const getScrubDate = useCallback(
+        (event: AnyTouchEvent) => {
+            const eDate = getDateFromEventPoint(event, windowRange);
+            const nearestFile = du.findNearestFileForDate(fileNames, eDate);
+            const scrubDate = nearestFile
+                ? du.parseFilenameDate(nearestFile)
+                : null;
+            return scrubDate;
+        },
+        [windowRange, fileNames, getDateFromEventPoint]
+    );
+
+    const handleMouseDown = (event: AnyTouchEvent) => {
+        event.preventDefault();
+        setIsScrubbing(true);
+
+        const scrubDate = getScrubDate(event);
+        setScrubDate(scrubDate);
+
+        // not sure yet if we want to call onPlayheadChange here
+        // if (scrubDate) onPlayheadChange(scrubDate);
     };
+
+    // This function is called from docuement mousemove and touchmove events
+    // which is why event type is MouseEvent | TouchEvent and not
+    // React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>
+    const handleMouseMove = useCallback(
+        (event: AnyTouchEvent) => {
+            if (!isScrubbing || !timelineRef.current) return;
+            setScrubDate(getScrubDate(event));
+        },
+        [isScrubbing, getScrubDate]
+    );
+
+    const handleMouseUp = useCallback(() => {
+        if (!isScrubbing) return;
+        setIsScrubbing(false);
+        if (scrubDate) {
+            console.log("Timeline setting playhead to", scrubDate);
+            onPlayheadChange(scrubDate);
+        }
+        setScrubDate(null);
+    }, [isScrubbing, onPlayheadChange, scrubDate]);
+
+    useEffect(() => {
+        // these are on the document so that we track the mouse even if it
+        // leaves the timeline element
+        document.addEventListener("mousemove", handleMouseMove);
+        document.addEventListener("mouseup", handleMouseUp);
+        document.addEventListener("touchmove", handleMouseMove);
+        document.addEventListener("touchend", handleMouseUp);
+
+        return () => {
+            document.removeEventListener("mousemove", handleMouseMove);
+            document.removeEventListener("mouseup", handleMouseUp);
+            document.removeEventListener("touchmove", handleMouseMove);
+            document.removeEventListener("touchend", handleMouseUp);
+        };
+    }, [handleMouseMove, handleMouseUp]);
+
+    const scrubberFile: string | null = useMemo(() => {
+        if (!scrubDate) return null;
+        const index = du.findNearestFileIndexForDate(fileNames, scrubDate);
+        return index === -1 ? null : fileNames[index];
+    }, [fileNames, scrubDate]);
+
+    const previewStyle = useMemo(() => {
+        if (!scrubDate || !timelineRef.current) return {};
+        const leftPct =
+            ((scrubDate.getTime() - windowRange.start.getTime()) /
+                windowRange.duration) *
+            100;
+        const offset = leftPct > 60 ? -300 : -150;
+        return { left: `calc(${leftPct}% + ${offset}px)` };
+    }, [scrubDate, windowRange]);
 
     return (
         <div className={st.outerContainer}>
-            <div className={st.timeline} onClick={handleTimelineClick}>
+            <div
+                ref={timelineRef}
+                className={st.timeline}
+                onMouseDown={handleMouseDown}
+                onTouchStart={handleMouseDown}
+            >
                 {thumbs}
             </div>
             <div className={st.playhead} style={{ left: `${playheadPct}%` }} />
@@ -88,6 +185,16 @@ export const Timeline: React.FC<TimelineProps> = ({
                     {windowRange.end.toLocaleString()}
                 </div>
             </div>
+            {scrubberFile !== null && (
+                <div className={st.scrubberPreview} style={previewStyle}>
+                    <div className={st.scrubberDate}>
+                        {scrubDate?.toLocaleString()}
+                    </div>
+                    <div className={st.scrubberThumb}>
+                        <img src={largeThumbUrl(scrubberFile)} />
+                    </div>
+                </div>
+            )}
         </div>
     );
 };

--- a/webapp/src/VidViewerDialog/Viewer.tsx
+++ b/webapp/src/VidViewerDialog/Viewer.tsx
@@ -9,7 +9,7 @@ import { PlayerControls } from "./PlayerControls";
 
 interface ViewerProps {
     // a string array of base file names retrieved from the basic_bot vision service
-    // filtered to selected filterRange
+    // filtered to selected filterRange and windowRange
     fileNames: string[];
     // current position of the playhead in seconds from the start of the window
     playheadPosition: Date;
@@ -30,13 +30,11 @@ export const Viewer: React.FC<ViewerProps> = ({
     onPlayheadChange,
 }) => {
     const videoRef = useRef<HTMLVideoElement>(null);
+    // This is different than the similarly named variable in the
+    // parent component. This is the index of the fileNames array
+    // which is filtered to windowRange
     const fileNamesIndex: number = useMemo(
-        () =>
-            fileNames.findIndex((fileName) => {
-                const date = du.parseFilenameDate(fileName);
-                const match = playheadPosition >= date;
-                return match;
-            }),
+        () => du.findNearestFileIndexForDate(fileNames, playheadPosition),
         [fileNames, playheadPosition]
     );
 

--- a/webapp/src/VidViewerDialog/dateUtils.ts
+++ b/webapp/src/VidViewerDialog/dateUtils.ts
@@ -101,3 +101,30 @@ export function contiguousRanges(fileNames: string[]): DateRange[] {
 
     return ranges;
 }
+
+export function findNearestFileIndexForDate(
+    filenames: string[],
+    date: Date
+): number {
+    const dateMs = date.getTime();
+    // TODO : this should probably be a binary search since the
+    // files are sorted in descending date order
+    return filenames.findIndex((fileName) => {
+        const parsedDate = parseFilenameDate(fileName);
+        console.log("comparing", {
+            date,
+            dateMs,
+            parsedDate,
+            parsedMs: parsedDate.getTime(),
+        });
+        return dateMs >= parsedDate.getTime();
+    });
+}
+
+export function findNearestFileForDate(
+    fileNames: string[],
+    date: Date
+): string {
+    const index = findNearestFileIndexForDate(fileNames, date);
+    return fileNames[index];
+}

--- a/webapp/src/VidViewerDialog/index.tsx
+++ b/webapp/src/VidViewerDialog/index.tsx
@@ -1,4 +1,4 @@
-import { act, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { videoHost } from "../util/hubState";
 
 import st from "./index.module.css";
@@ -84,11 +84,7 @@ export const VidViewerDialog: React.FC<VidViewerDialogProps> = ({
 
     const filteredFileNamesIndex: number = useMemo(
         () =>
-            filteredFileNames.findIndex((fileName) => {
-                const date = du.parseFilenameDate(fileName);
-                const match = playheadPosition >= date;
-                return match;
-            }),
+            du.findNearestFileIndexForDate(filteredFileNames, playheadPosition),
         [filteredFileNames, playheadPosition]
     );
 
@@ -172,18 +168,16 @@ export const VidViewerDialog: React.FC<VidViewerDialogProps> = ({
             if (filteredFileNames.length === 0) {
                 return;
             }
-            const nextFilenamesIndex = filteredFileNames.findIndex(
-                (fileName) => {
-                    return (
-                        newPlayheadPosition >= du.parseFilenameDate(fileName)
-                    );
-                }
+
+            const nextFilenamesIndex = du.findNearestFileIndexForDate(
+                filteredFileNames,
+                newPlayheadPosition
             );
-            if (nextFilenamesIndex < 1) {
+            if (nextFilenamesIndex < 0) {
                 return;
             }
             const adjPlayheadPosition = du.parseFilenameDate(
-                filteredFileNames[nextFilenamesIndex - 1]
+                filteredFileNames[nextFilenamesIndex]
             );
             setPlayheadPosition(adjPlayheadPosition);
             adjustWindowRangeToNewPlayhead(adjPlayheadPosition);

--- a/webapp/src/VidViewerDialog/touchUtils.ts
+++ b/webapp/src/VidViewerDialog/touchUtils.ts
@@ -1,0 +1,27 @@
+export type AnyTouchEvent =
+    | React.TouchEvent
+    | React.MouseEvent
+    | MouseEvent
+    | TouchEvent;
+
+export function isTouchEvent(
+    e: AnyTouchEvent
+): e is React.TouchEvent | TouchEvent {
+    if (e instanceof TouchEvent) {
+        return true;
+    }
+    if (e instanceof MouseEvent) {
+        return false;
+    }
+    // ^ native event, below is React event
+    return e.nativeEvent instanceof TouchEvent;
+}
+
+// returns [x, y] coordinates of the mouse or touch event
+export function getClientXY(e: AnyTouchEvent): [number, number] {
+    if (isTouchEvent(e)) {
+        const touch = e.touches[0];
+        return [touch.clientX, touch.clientY];
+    }
+    return [e.clientX, e.clientY];
+}

--- a/webapp/src/util/vidUtils.ts
+++ b/webapp/src/util/vidUtils.ts
@@ -13,5 +13,5 @@ export function thumbUrl(baseFilename: string): string {
 }
 
 export function largeThumbUrl(baseFilename: string): string {
-    return vidFileUrl(`${baseFilename}.jpg`);
+    return vidFileUrl(`${baseFilename}_lg.jpg`);
 }


### PR DESCRIPTION

When the user clicks or touches the timeline and holds or drags show them a preview of the nearest recorded segment.  

Looks like this:


https://github.com/user-attachments/assets/db80e3be-56b6-4ffb-8cb2-7e2f3516b01a

