### PR TITLE
Add setup for auto starting daphbbot services from systemd

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# to automatically run our start script on desktop login
+cp setup_files/home/.config/systemd/user/daphbot.service ~/.config/systemd/user/
+systemctl --user enable daphbot.service

--- a/setup_files/home/.config/systemd/user/daphbot.service
+++ b/setup_files/home/.config/systemd/user/daphbot.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Auto start daphbot script at Gnome startup
+After=graphical-session.target
+
+[Service]
+Type=oneshot
+ExecStart=/home/bee/daphbot_due/start.sh
+WorkingDirectory=/home/bee/daphbot_due
+RemainAfterExit=yes
+
+[Install]
+WantedBy=graphical-csession.target

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,6 @@
-#!/bin/sh
+#!/bin/bash
+
+source ~/bb_env/bin/activate
+export BB_ENV=production
+
 bb_start $@


### PR DESCRIPTION

Setup script runs on bot onboard computer.  Verified working with Bookworm 64bit + desktop.  