### PR TITLE
linting polish

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -7,5 +7,5 @@ echo "Linting with flake8..."
 python -m flake8 src
 
 echo "Running mypy (typechecker): $(python -m mypy --version)"
-PYTHONPATH=src python -m mypy --explicit-package-bases src
+python -m mypy src
 

--- a/lint.sh
+++ b/lint.sh
@@ -3,9 +3,9 @@
 # fail on any error
 set -e
 
-echo "Linting with flake8..."
+echo "Linting with flake8 (Python linter): $(python -m flake8 --version)"
 python -m flake8 src
 
-echo "Running mypy (typechecker): $(python -m mypy --version)"
+echo "Running mypy (Python typechecker): $(python -m mypy --version)"
 python -m mypy src
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -12,6 +12,7 @@ exclude = node_modules
 no_site_packages = False
 mypy_path = src
 namespace_packages = True
+explicit_package_bases = True
 
 [mypy-basic_bot.*]
 ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,9 +5,6 @@ aiohttp
 aiohttp-cors
 aiortc
 cffi
-flake8>=7.3.0
-mypy
-pyflakes>=3.4.0
 opencv-python
 pycparser
 pydub
@@ -16,3 +13,10 @@ pytest
 pyttsx3
 scipy
 sounddevice
+
+# linting and type checking. These should be fixed to a specific version that
+# works on mac, windows, and linux.  This will minimize "it works on my machine
+# but not on CI" issues.
+flake8==7.3
+mypy==1.14
+pyflakes==3.4.0


### PR DESCRIPTION
I didn't notice these before merging the lint PR.  the call to mypy in lint.sh can be simplified:
1. don't need PYTHONPATH=src for mypy.  that was something Claude hallucinated
2. command line switch added should be in mypy.ini