### PR TITLE
Add demostration of how to override basic_bot_react styling

### DIFF
--- a/webapp/src/App.module.css
+++ b/webapp/src/App.module.css
@@ -1,4 +1,4 @@
-/* This is an arbritrary custom style for to demonstrate how we can style
+/* This is an arbritrary custom style to demonstrate how we can style
    the PanTilt component from basic_bot_react.
 */
 .customPanTilt {

--- a/webapp/src/App.module.css
+++ b/webapp/src/App.module.css
@@ -1,0 +1,11 @@
+/* This is an arbritrary custom style for to demonstrate how we can style
+   the PanTilt component from basic_bot_react.
+*/
+.customPanTilt {
+    background-color: rgba(0, 0, 255, 0.3);
+
+    /* We will try not to change the existing classnames applied to component elements */
+    div[class*="angleActualXY"] {
+        background-color: #f00;
+    }
+}

--- a/webapp/src/App.module.css
+++ b/webapp/src/App.module.css
@@ -2,9 +2,15 @@
    the PanTilt component from basic_bot_react.
 */
 .customPanTilt {
+    /* change the background color of the outer most element */
     background-color: rgba(0, 0, 255, 0.3);
 
-    /* We will try not to change the existing classnames applied to component elements */
+    /* change the background color of normally green dot that marks the
+       current angle to red.
+
+       We will try not to change the existing classnames applied to
+       component elements
+    */
     div[class*="angleActualXY"] {
         background-color: #f00;
     }

--- a/webapp/src/App.tsx
+++ b/webapp/src/App.tsx
@@ -21,6 +21,8 @@ import { VideoViewer } from "./VideoViewer";
 import { WebRTCStream } from "./components/WebRTCStream";
 import { VideoFeedType } from "./util/videoPreferences";
 
+import st from "./App.module.css";
+
 interface AppProps {
     hubPort?: number;
     autoReconnect?: boolean;
@@ -100,7 +102,9 @@ function AppContent() {
                                     />
                                 </div>
                                 {hubState.daphbot_mode ===
-                                    BehaviorMode.Manual && <PanTilt />}
+                                    BehaviorMode.Manual && (
+                                    <PanTilt className={st.customPanTilt} />
+                                )}
                             </>
                         )}
                     </div>


### PR DESCRIPTION
Add demonstration of using className on basic_bot_react components to arbitrarily restyle PanTilt usage here in.